### PR TITLE
Add From impls for io::Error

### DIFF
--- a/src/mapped_tcp_socket.rs
+++ b/src/mapped_tcp_socket.rs
@@ -73,6 +73,16 @@ quick_error! {
     }
 }
 
+impl From<MappedTcpSocketMapError> for io::Error {
+    fn from(e: MappedTcpSocketMapError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            MappedTcpSocketMapError::SocketLocalAddr { err } => err.kind(),
+        };
+        io::Error::new(kind, err_str)
+    }
+}
+
 quick_error! {
     /// Warnings raised by MappedTcpSocket::map
     #[derive(Debug)]
@@ -169,6 +179,23 @@ quick_error! {
     }
 }
 
+impl From<MappedTcpSocketNewError> for io::Error {
+    fn from(e: MappedTcpSocketNewError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            MappedTcpSocketNewError::CreateSocket { err } => err.kind(),
+            MappedTcpSocketNewError::EnableReuseAddr { err } => err.kind(),
+            MappedTcpSocketNewError::EnableReusePort { err } => err.kind(),
+            MappedTcpSocketNewError::Bind { err } => err.kind(),
+            MappedTcpSocketNewError::Map { err } => {
+                let err: io::Error = From::from(err);
+                err.kind()
+            },
+        };
+        io::Error::new(kind, err_str)
+    }
+}
+
 quick_error! {
     /// Errors returned by new_reusably_bound_socket
     #[derive(Debug)]
@@ -199,6 +226,19 @@ quick_error! {
                      set", err)
             cause(err)
         }
+    }
+}
+
+impl From<NewReusablyBoundSocketError> for io::Error {
+    fn from(e: NewReusablyBoundSocketError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            NewReusablyBoundSocketError::Create { err } => err.kind(),
+            NewReusablyBoundSocketError::EnableReuseAddr { err } => err.kind(),
+            NewReusablyBoundSocketError::EnableReusePort { err } => err.kind(),
+            NewReusablyBoundSocketError::Bind { err } => err.kind(),
+        };
+        io::Error::new(kind, err_str)
     }
 }
 
@@ -497,6 +537,22 @@ quick_error! {
             display("Tcp hole punching timed out without making a successful connection. The \
                      following warnings were raised during hole punching: {}", DisplayWarnings(warnings))
         }
+    }
+}
+
+impl From<TcpPunchHoleError> for io::Error {
+    fn from(e: TcpPunchHoleError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            TcpPunchHoleError::SocketLocalAddr { err } => err.kind(),
+            TcpPunchHoleError::NewReusablyBoundSocket { err } => {
+                let err: io::Error = From::from(err);
+                err.kind()
+            },
+            TcpPunchHoleError::Listen { err } => err.kind(),
+            TcpPunchHoleError::TimedOut { .. } => io::ErrorKind::TimedOut,
+        };
+        io::Error::new(kind, err_str)
     }
 }
 

--- a/src/mapped_udp_socket.rs
+++ b/src/mapped_udp_socket.rs
@@ -81,6 +81,18 @@ quick_error! {
     }
 }
 
+impl From<MappedUdpSocketMapError> for io::Error {
+    fn from(e: MappedUdpSocketMapError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            MappedUdpSocketMapError::SocketLocalAddr { err } => err.kind(),
+            MappedUdpSocketMapError::RecvError { err } => err.kind(),
+            MappedUdpSocketMapError::SendError { err } => err.kind(),
+        };
+        io::Error::new(kind, err_str)
+    }
+}
+
 quick_error! {
     /// Warnings raised by MappedUdpSocket::map
     #[derive(Debug)]
@@ -133,6 +145,20 @@ quick_error! {
                      an error: {}", err)
             cause(err)
         }
+    }
+}
+
+impl From<MappedUdpSocketNewError> for io::Error {
+    fn from(e: MappedUdpSocketNewError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            MappedUdpSocketNewError::CreateSocket { err } => err.kind(),
+            MappedUdpSocketNewError::MapSocket { err } => {
+                let err: io::Error = From::from(err);
+                err.kind()
+            },
+        };
+        io::Error::new(kind, err_str)
     }
 }
 

--- a/src/mapping_context.rs
+++ b/src/mapping_context.rs
@@ -79,6 +79,17 @@ quick_error! {
     }
 }
 
+impl From<MappingContextNewError> for io::Error {
+    fn from(e: MappingContextNewError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            MappingContextNewError::ListInterfaces { err } => err.kind(),
+            MappingContextNewError::SpawnThread { err } => err.kind(),
+        };
+        io::Error::new(kind, err_str)
+    }
+}
+
 quick_error! {
     #[derive(Debug)]
     pub enum MappingContextNewWarning {

--- a/src/punched_udp_socket.rs
+++ b/src/punched_udp_socket.rs
@@ -116,16 +116,14 @@ quick_error! {
 }
 
 impl From<UdpPunchHoleError> for io::Error {
-    fn from(err: UdpPunchHoleError) -> io::Error {
-        match err {
-            UdpPunchHoleError::TimedOut => io::Error::new(io::ErrorKind::TimedOut,
-                                                          "Udp hole punching timed out waiting \
-                                                           for a response from the peer"),
-            UdpPunchHoleError::Io { err } => err,
-            UdpPunchHoleError::SendCompleteAck => io::Error::new(io::ErrorKind::Other,
-                                                                 "Error sending ACK to peer. Kept \
-                                                                  getting partial writes."),
-        }
+    fn from(e: UdpPunchHoleError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            UdpPunchHoleError::TimedOut => io::ErrorKind::TimedOut,
+            UdpPunchHoleError::Io { err } => err.kind(),
+            UdpPunchHoleError::SendCompleteAck => io::ErrorKind::Other,
+        };
+        io::Error::new(kind, err_str)
     }
 }
 

--- a/src/simple_tcp_hole_punch_server.rs
+++ b/src/simple_tcp_hole_punch_server.rs
@@ -72,6 +72,21 @@ quick_error! {
     }
 }
 
+impl From<SimpleTcpHolePunchServerNewError> for io::Error {
+    fn from(e: SimpleTcpHolePunchServerNewError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            SimpleTcpHolePunchServerNewError::CreateMappedSocket { err } => {
+                let err: io::Error = From::from(err);
+                err.kind()
+            },
+            SimpleTcpHolePunchServerNewError::Listen { err } => err.kind(),
+            SimpleTcpHolePunchServerNewError::SocketLocalAddr { err } => err.kind(),
+        };
+        io::Error::new(kind, err_str)
+    }
+}
+
 impl<'a> SimpleTcpHolePunchServer<'a> {
     /// Create a new server. This will spawn a background thread which will serve requests until
     /// the server is dropped.

--- a/src/simple_udp_hole_punch_server.rs
+++ b/src/simple_udp_hole_punch_server.rs
@@ -67,6 +67,20 @@ quick_error! {
     }
 }
 
+impl From<SimpleUdpHolePunchServerNewError> for io::Error {
+    fn from(e: SimpleUdpHolePunchServerNewError) -> io::Error {
+        let err_str = format!("{}", e);
+        let kind = match e {
+            SimpleUdpHolePunchServerNewError::CreateMappedSocket { err } => {
+                let err: io::Error = From::from(err);
+                err.kind()
+            },
+            SimpleUdpHolePunchServerNewError::SetSocketTimeout { err } => err.kind(),
+        };
+        io::Error::new(kind, err_str)
+    }
+}
+
 impl<'a> SimpleUdpHolePunchServer<'a> {
     /// Create a new server. This will spawn a background thread which will serve requests until
     /// the server is dropped.


### PR DESCRIPTION
Adds a conversion for every error type to `io::Error`. Useful in crust where we (over)use `io::Error` a lot.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/nat_traversal/50)

<!-- Reviewable:end -->
