### PR TITLE
refactor: change Simple{Tcp,Udp}HolePunchServer to use AsRef

### DIFF
--- a/examples/simple-tcp-server.rs
+++ b/examples/simple-tcp-server.rs
@@ -60,7 +60,7 @@ fn main() {
     };
 
     // Now we create the server.
-    let simple_server = match SimpleTcpHolePunchServer::new(&mapping_context) {
+    let simple_server = match SimpleTcpHolePunchServer::new(Box::new(mapping_context)) {
         WOk(simple_server, warnings) => {
             for warning in warnings {
                 println!("Warning when creating simple server: {}", warning);

--- a/examples/simple-udp-server.rs
+++ b/examples/simple-udp-server.rs
@@ -60,7 +60,7 @@ fn main() {
     };
 
     // Now we create the server.
-    let simple_server = match SimpleUdpHolePunchServer::new(&mapping_context) {
+    let simple_server = match SimpleUdpHolePunchServer::new(Box::new(mapping_context)) {
         WOk(simple_server, warnings) => {
             for warning in warnings {
                 println!("Warning when creating simple server: {}", warning);


### PR DESCRIPTION
This changed was needed to allow code structure like the following to
work: https://gist.github.com/vinipsmaker/3a2b7afee04e2f4e6a79

Hint to use `AsRef` by Andrew Cann.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/nat_traversal/55)

<!-- Reviewable:end -->
