### PR TITLE
Rename and export new_reusably_bound_socket

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,10 @@ pub use rendezvous_info::{PrivRendezvousInfo, PubRendezvousInfo,
 pub use mapped_udp_socket::{MappedUdpSocket, MappedUdpSocketMapError,
                             MappedUdpSocketMapWarning, MappedUdpSocketNewError};
 pub use punched_udp_socket::{PunchedUdpSocket, filter_udp_hole_punch_packet};
-pub use mapped_tcp_socket::{MappedTcpSocket, tcp_punch_hole};
+pub use mapped_tcp_socket::{new_reusably_bound_tcp_socket, MappedTcpSocket, tcp_punch_hole,
+                            MappedTcpSocketMapError, MappedTcpSocketMapWarning,
+                            MappedTcpSocketNewError, NewReusablyBoundTcpSocketError,
+                            TcpPunchHoleWarning, TcpPunchHoleError};
 pub use simple_udp_hole_punch_server::{SimpleUdpHolePunchServer, SimpleUdpHolePunchServerNewError};
 pub use simple_tcp_hole_punch_server::{SimpleTcpHolePunchServer, SimpleTcpHolePunchServerNewError};
 


### PR DESCRIPTION
Also export a bunch of types from `mapped_tcp_socket`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/nat_traversal/58)

<!-- Reviewable:end -->
